### PR TITLE
fix: merge fix/13-fix-calculate-indicators-using-correctly-sorted-data (#14)

### DIFF
--- a/FomoApp/Fomo.Application/Services/Indicators/ParseListHelper.cs
+++ b/FomoApp/Fomo.Application/Services/Indicators/ParseListHelper.cs
@@ -1,7 +1,5 @@
 ﻿using Fomo.Application.DTO.StockDataDTO;
 using System.Globalization;
-using System.Linq.Expressions;
-
 
 namespace Fomo.Application.Services.Indicators
 {
@@ -21,6 +19,8 @@ namespace Fomo.Application.Services.Indicators
                 decimal.TryParse(value, CultureInfo.InvariantCulture, out Price);
                 valuesd.Add(Price);
             }
+
+            valuesd.Reverse();
 
             return valuesd;
         }


### PR DESCRIPTION
### Summary
Fixes an issue where the indicator calculations were based on reversed data.

### Details
-Updated ParseListHelper to reverse the data before returning the list

### Related Issue
Closes #12 