### PR TITLE
merge:  feature/25-feat-decouple-trade-results-from-user-details (#26)

### DIFF
--- a/FomoApp/Fomo.Api/Controllers/UserController.cs
+++ b/FomoApp/Fomo.Api/Controllers/UserController.cs
@@ -1,5 +1,4 @@
-﻿using Fomo.Application.DTO.TradeResult;
-using Fomo.Application.DTO.User;
+﻿using Fomo.Application.DTO.User;
 using Fomo.Domain.Entities;
 using Fomo.Infrastructure.Repositories;
 using Microsoft.AspNetCore.Authorization;
@@ -57,34 +56,9 @@ namespace Fomo.Api.Controllers
 
             if (auth0Id == null) return BadRequest("User must be authenticated");
 
-            var userData = await _userRepository.GetByAuth0IdAsync(auth0Id);
+            var userData = await _userRepository.GetOnlyUserByAuth0IdAsync(auth0Id);
 
             if (userData == null) return NotFound("Invalid User");
-
-            var tradeResultsDTO = new List<TradeResultDTO>();
-            if (userData.TradeResults != null)
-            {
-                tradeResultsDTO = userData.TradeResults.Select(tr => new TradeResultDTO
-                {
-                    TradeResultId = tr.TradeResultId,
-                    Symbol = tr.Symbol,
-                    EntryPrice = tr.EntryPrice,
-                    ExitPrice = tr.ExitPrice,
-                    Profit = tr.Profit,
-                    NumberOfStocks = tr.NumberOfStocks,
-                    EntryDate = tr.EntryDate,
-                    ExitDate = tr.ExitDate,
-                    TradeMethod = new TradeMethodDTO
-                    {
-                        Sma = tr.TradeMethod?.Sma ?? false,
-                        Bollinger = tr.TradeMethod?.Bollinger ?? false,
-                        Stochastic = tr.TradeMethod?.Stochastic ?? false,
-                        Rsi = tr.TradeMethod?.Rsi ?? false,
-                        Other = tr.TradeMethod?.Other ?? false,
-                    },
-                    UserName = userData.Name,
-                }).ToList();
-            }
 
             var userDto = new UserDTO()
             {
@@ -93,7 +67,6 @@ namespace Fomo.Api.Controllers
                 BollingerAlert = userData.BollingerAlert,
                 StochasticAlert = userData.StochasticAlert,
                 RsiAlert = userData.RsiAlert,
-                TradeResults = tradeResultsDTO,
             };
 
             return Ok(userDto);

--- a/FomoApp/Fomo.Application/DTO/User/UserDTO.cs
+++ b/FomoApp/Fomo.Application/DTO/User/UserDTO.cs
@@ -9,6 +9,5 @@ namespace Fomo.Application.DTO.User
         public bool? BollingerAlert { get; set; }
         public bool? StochasticAlert { get; set; }
         public bool? RsiAlert { get; set; }
-        public List<TradeResultDTO>? TradeResults { get; set; }
     }
 }

--- a/FomoApp/Fomo.Infraestructure/Repositories/ITradeResultRepository.cs
+++ b/FomoApp/Fomo.Infraestructure/Repositories/ITradeResultRepository.cs
@@ -7,7 +7,9 @@ namespace Fomo.Infrastructure.Repositories
     {
         Task<TradeResult?> GetByIdAsync(int id);
         Task<List<TradeResultDTO>> GetPaginatedAsync(int page, int pageSize);
+        Task<List<TradeResultDTO>> GetPaginatedByUserAsync(int page, int pageSize, int user);
         Task<int> CountRecordsAsync();
+        Task<int> CountRecordsByUserAsync(int user);
         Task InsertAsync(TradeResult tradeResult);
         Task<bool> DeleteIfExistsAsync(int id);
         Task SaveAsync();

--- a/FomoApp/Fomo.Infraestructure/Repositories/IUserRepository.cs
+++ b/FomoApp/Fomo.Infraestructure/Repositories/IUserRepository.cs
@@ -4,7 +4,6 @@ namespace Fomo.Infrastructure.Repositories
 {
     public interface IUserRepository
     {
-        Task<User?> GetByAuth0IdAsync(string auth0id);
         Task<User?> GetOnlyUserByAuth0IdAsync(string auth0id);
         Task<int?> GetUserIdByAuth0IdAsync(string auth0id);
         Task<List<NameAndMail>> GetUsersByAlertAsync(AlertType alertType);

--- a/FomoApp/Fomo.Infraestructure/Repositories/TradeResultRepository.cs
+++ b/FomoApp/Fomo.Infraestructure/Repositories/TradeResultRepository.cs
@@ -24,6 +24,7 @@ namespace Fomo.Infrastructure.Repositories
         public async Task<List<TradeResultDTO>> GetPaginatedAsync(int page, int pageSize)
         {
             if (page < 1) page = 1;
+            if (pageSize < 1) pageSize = 10;
 
             var resultsList = await _dbContext.TradeResults
                 .AsNoTracking()
@@ -55,9 +56,54 @@ namespace Fomo.Infrastructure.Repositories
             return resultsList;
         }
 
+        public async Task<List<TradeResultDTO>> GetPaginatedByUserAsync(int page, int pageSize, int user)
+        {
+            if (page < 1) page = 1;
+            if (pageSize < 1) pageSize = 10;
+
+            var resultsList = await _dbContext.TradeResults
+                .AsNoTracking()
+                .Where(tr => tr.UserId == user)
+                .OrderByDescending(tr => tr.EntryDate)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Select(tr => new TradeResultDTO
+                {
+                    TradeResultId = tr.TradeResultId,
+                    Symbol = tr.Symbol,
+                    EntryPrice = tr.EntryPrice,
+                    ExitPrice = tr.ExitPrice,
+                    Profit = tr.Profit,
+                    NumberOfStocks = tr.NumberOfStocks,
+                    EntryDate = tr.EntryDate,
+                    ExitDate = tr.ExitDate,
+                    TradeMethod = new TradeMethodDTO
+                    {
+                        Sma = tr.TradeMethod.Sma,
+                        Bollinger = tr.TradeMethod.Bollinger,
+                        Stochastic = tr.TradeMethod.Stochastic,
+                        Rsi = tr.TradeMethod.Rsi,
+                        Other = tr.TradeMethod.Other
+                    },
+                    UserName = tr.User.Name
+                })
+                .ToListAsync();
+
+            return resultsList;
+        }
+
         public async Task<int> CountRecordsAsync()
         {
             var numberOfRecords = await _dbContext.TradeResults
+                .CountAsync();
+
+            return numberOfRecords;
+        }
+
+        public async Task<int> CountRecordsByUserAsync(int user)
+        {
+            var numberOfRecords = await _dbContext.TradeResults
+                .Where(tr => tr.UserId == user)
                 .CountAsync();
 
             return numberOfRecords;

--- a/FomoApp/Fomo.Infraestructure/Repositories/UserRepository.cs
+++ b/FomoApp/Fomo.Infraestructure/Repositories/UserRepository.cs
@@ -13,14 +13,6 @@ namespace Fomo.Infrastructure.Repositories
             _dbContext = dbContext;
         }
 
-        public async Task<User?> GetByAuth0IdAsync(string auth0id)
-        {
-            return await _dbContext.Users
-                .Include(u => u.TradeResults)
-                    .ThenInclude(tr => tr.TradeMethod)
-                .FirstOrDefaultAsync(u => u.Auth0Id == auth0id);
-        }
-
         public async Task<User?> GetOnlyUserByAuth0IdAsync(string auth0id)
         {
             return await _dbContext.Users


### PR DESCRIPTION
### Summary
Decouple trade results from the user details endpoint and implement a paginated endpoint to retrieve trade results by user.

### Details
-Removed trade results from UserDTO
-Updated UserDetails in UserController to no longer return trade results
-Removed GetByAuth0IdAsync from UserRepository and replaced it with GetOnlyUserByAuth0IdAsync
-Added CountRecordsByUserAsync and GetPaginatedByUserAsync methods to TradeResultRepository
-Added GetTradeResultsPageByUser endpoint in TradeResultController

### Related Issue
Closes #25