### PR TITLE
merge: feature/29-feat-add-caching-to-twelvedataservice-time-series-retrieval (#30)

### DIFF
--- a/FomoApp/Fomo.Api/Program.cs
+++ b/FomoApp/Fomo.Api/Program.cs
@@ -34,6 +34,8 @@ builder.Services.AddCors(options =>
     });
 });
 
+builder.Services.AddMemoryCache();
+
 builder.Services
     .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>

--- a/FomoApp/Fomo.Infraestructure/ExternalServices/StockService/TwelveDataService.cs
+++ b/FomoApp/Fomo.Infraestructure/ExternalServices/StockService/TwelveDataService.cs
@@ -1,15 +1,18 @@
 ﻿using Fomo.Application.DTO.StockDataDTO;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
 
 namespace Fomo.Infrastructure.ExternalServices.StockService
 {
     public class TwelveDataService : ITwelveDataService
     {
+        private readonly IMemoryCache _cache;
         private readonly IExternalApiHelper _externalApiHelper;
         private readonly TwelveData _twelveData;
 
-        public TwelveDataService(IOptions<TwelveData> options, IExternalApiHelper externalApiHelper)
+        public TwelveDataService(IMemoryCache cache, IOptions<TwelveData> options, IExternalApiHelper externalApiHelper)
         {
+            _cache = cache;
             _externalApiHelper = externalApiHelper;
             _twelveData = options.Value;
         }
@@ -23,9 +26,26 @@ namespace Fomo.Infrastructure.ExternalServices.StockService
 
         public async Task<ValuesResponseDTO?> GetTimeSeries(string symbol)
         {
+            var cacheKey = $"timeseries_{symbol}";
+
+            if (_cache.TryGetValue(cacheKey, out ValuesResponseDTO? cached))
+            {
+                return cached;
+            }
+
             string path = $"time_series?symbol={symbol}&interval=1day&outputsize=120&apikey={_twelveData.ApiKey}";
 
-            return await _externalApiHelper.GetAsync<ValuesResponseDTO>(path);
+            var result = await _externalApiHelper.GetAsync<ValuesResponseDTO>(path);
+
+            var options = new MemoryCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10),
+                SlidingExpiration = TimeSpan.FromMinutes(5)
+            };
+
+            _cache.Set(cacheKey, result, options);
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
### Summary
Adds caching to the TwelveDataService time series retrieval, reducing redundant external API calls by reusing data for chart rendering and indicator calculations.

### Details
-Added in-memory caching configuration in Program.cs
-Implemented caching in GetTimeSeries method within TwelveDataService
-Returned cached time series data when available to avoid redundant external API calls
-Defined cache expiration policy for time series data

### Related Issue
Closes #29 