### PR TITLE
merge: feature/16-create-html-body-to-mail-alerts (#31)

### DIFF
--- a/FomoApp/Fomo.Api/Controllers/IndicatorsController.cs
+++ b/FomoApp/Fomo.Api/Controllers/IndicatorsController.cs
@@ -46,7 +46,7 @@ namespace Fomo.Api.Controllers
             var parser = new ParseListHelper();
             var closes = parser.ParseList(timeseries.Values, v => v.Close);
 
-            string indicator = $"SMA with a period of {period}";
+            string indicator = $"SMA con un período de {period}";
             await _alertService.SendSmaAlert(closes, sma.Values, symbol, indicator);
 
             return Ok(sma);
@@ -102,7 +102,7 @@ namespace Fomo.Api.Controllers
             var parser = new ParseListHelper();
             var closes = parser.ParseList(timeseries.Values, v => v.Close);
 
-            string indicator = $"Bollinger Bands with a period of {period} and a k of {k}";
+            string indicator = $"Bandas de Bollinger con un período de {period} y k={k}";
             await _alertService.SendBollingerAlert(closes, bollingerBands.LowerBand, symbol, indicator);
 
             return Ok(bollingerBands);
@@ -130,7 +130,7 @@ namespace Fomo.Api.Controllers
 
             var stochasticOscillator = _indicatorService.GetStochastic(timeseries.Values, period, smaperiod);
 
-            string indicator = $"Stochastic Oscilator with a period of {period} and a SMA period of {smaperiod}";
+            string indicator = $"Oscilador Estocástico con un período de {period} utilizando un SMA con período de {smaperiod}";
             await _alertService.SendStochasticAlert(stochasticOscillator.K, stochasticOscillator.D, symbol, indicator);
 
             return Ok(stochasticOscillator);
@@ -155,7 +155,7 @@ namespace Fomo.Api.Controllers
 
             var rsi = _indicatorService.GetRSI(timeseries.Values, period);
 
-            string indicator = $"RSI with a period of {period}";
+            string indicator = $"RSI con un período de {period}";
             await _alertService.SendRsiAlert(rsi.Values, symbol, indicator);
 
             return Ok(rsi);
@@ -180,7 +180,7 @@ namespace Fomo.Api.Controllers
 
             var wrsi = _indicatorService.GetWilderRSI(timeseries.Values, period);
 
-            string indicator = $"Wilder RSI with a period of {period}";
+            string indicator = $"RSI de Wilder con un período de of {period}";
             await _alertService.SendRsiAlert(wrsi.Values, symbol, indicator);
 
             return Ok(wrsi);

--- a/FomoApp/Fomo.Api/Controllers/StocksController.cs
+++ b/FomoApp/Fomo.Api/Controllers/StocksController.cs
@@ -81,12 +81,12 @@ namespace Fomo.Api.Controllers
 
             var mainchannel = _indicatorService.GetMainChannel(timeseries.Values);
 
-            timeseries.Values.Reverse();
+            var reversedValues = timeseries.Values.AsEnumerable().Reverse().ToList();
 
             var response = new ValuesAndChannelDTO
             {
                 MetaDTO = timeseries.MetaDTO,
-                Values = timeseries.Values,
+                Values = reversedValues,
                 Regression = mainchannel.Regression,
                 Upper = mainchannel.Upper,
                 Lower = mainchannel.Lower,

--- a/FomoApp/Fomo.Infraestructure/ExternalServices/MailService/Alerts/GenericAlert.cs
+++ b/FomoApp/Fomo.Infraestructure/ExternalServices/MailService/Alerts/GenericAlert.cs
@@ -18,16 +18,82 @@ namespace Fomo.Infrastructure.ExternalServices.MailService.Alerts
         {
             var usersList = await _userRepository.GetUsersByAlertAsync(alertType);
 
-            string subject = "New Stock Alert";
+            string subject = "🚀 Nueva Alerta de FOMO";
 
             if (usersList != null)
             {
                 foreach (var user in usersList)
                 {
-                    string body = $"Hello {user.Name}!!\nA user achieved a positive outcome for the {stock} stock by using {indicator}";
+                    string body = BuildAlertEmail(user.Name, stock, indicator);
                     await _emailService.SendAsync(user.Email, subject, body);
                 }
             }
+        }
+
+        private string BuildAlertEmail(string userName, string stock, string indicator)
+        {
+            return $@"
+            <!DOCTYPE html>
+            <html>
+            <head>
+                <meta charset='UTF-8'>
+                <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+            </head>
+            <body style='margin:0; padding:0; background-color:#f3f4f6; font-family: system-ui, Arial, sans-serif;'>
+
+            <div style='max-width:600px; margin:40px auto; background:#ffffff; border-radius:12px; overflow:hidden; border:1px solid #e0e0e0;'>
+            
+                <!-- Header -->
+                <div style='background:#333; padding:24px 32px; display:flex; align-items:center;'>
+                    <span style='color:#ffffff; font-size:24px; font-weight:800; letter-spacing:-0.5px;'>FOMO 🚀</span>
+                </div>
+
+                <!-- Body -->
+                <div style='padding:32px;'>
+                    <h2 style='margin:0 0 8px 0; font-size:20px; color:#111;'>¡Hola, {userName}!</h2>
+                    <p style='margin:0 0 24px 0; color:#555; font-size:15px; line-height:1.5;'>
+                        Un usuario obtuvo un resultado positivo que podría interesarte.
+                    </p>
+
+                    <!-- Card -->
+                    <div style='background:#f8f8f8; border:1px solid #ddd; border-radius:10px; overflow:hidden; margin-bottom:24px;'>
+                        <div style='padding:12px 20px; border-bottom:1px solid #ddd;'>
+                            <span style='font-size:12px; color:#555; font-weight:500; text-transform:uppercase; letter-spacing:0.05em;'>Resultado destacado</span>
+                        </div>
+                        <div style='padding:20px;'>
+                            <table style='border-collapse:collapse; width:100%;'>
+                                <tr>
+                                    <td style='vertical-align:top; padding-right:20px; width:80px;'>
+                                        <span style='font-size:32px; font-weight:800; color:#111;'>{stock}</span>
+                                    </td>
+                                    <td style='vertical-align:top;'>
+                                        <div style='font-size:12px; color:#555; margin-bottom:4px;'>Indicador</div>
+                                        <div style='font-size:13px; font-weight:600; color:#3b82f6; border:1px solid #3b82f6; border-radius:8px; padding:6px 12px; display:inline-block;'>
+                                            {indicator}
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </div>
+
+                    <p style='margin:0; color:#9ca3af; font-size:13px; line-height:1.5;'>
+                        Recordá que los indicadores <strong>NO SON GARANTÍA</strong> de éxito.<br/>
+                        El único propósito de este sitio es académico.
+                    </p>
+                </div>
+
+                <!-- Footer -->
+                <div style='background:#333; padding:16px 32px; text-align:center;'>
+                    <p style='margin:0; color:#9ca3af; font-size:12px;'>
+                        FOMO
+                    </p>
+                </div>
+
+            </div>
+
+        </body>
+        </html>";
         }
     }
 }

--- a/FomoApp/Fomo.Infraestructure/ExternalServices/MailService/EmailService.cs
+++ b/FomoApp/Fomo.Infraestructure/ExternalServices/MailService/EmailService.cs
@@ -24,7 +24,7 @@ namespace Fomo.Infrastructure.ExternalServices.MailService
 
             var mail = new MailMessage($"{_settings.Email}", to, subject, body)
             {
-                IsBodyHtml = false
+                IsBodyHtml = true
             };
 
             await smtp.SendMailAsync(mail);


### PR DESCRIPTION
### Summary
Implements an HTML template to be used as the email body when sending alert notifications.

### Details
-Enabled HTML email body in EmailService
-Created BuildAlertEmail method in GenericAlert to generate the email template
-Updated alert messages in IndicatorsController
-Fixed reversed cache values in GetStockTimeSeries (StockController)

### Related Issue
Closes #16 